### PR TITLE
Update: Add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Add some custom overrides for language detection
+
+# app exported files must be js and are merged in a consuming application
+packages/*/app/**/*.js -linguist-detectable
+# js bundled with the webservice
+packages/webservice/**/*.{js,css,html} -linguist-vendored


### PR DESCRIPTION
## Description
This will give a more accurate counting of TS vs JS in our repo

As of now the breakdown is

![github-linguist breakdown](https://user-images.githubusercontent.com/12093492/110955226-fc439380-830e-11eb-957d-dc05f4958fd5.png)

but this also includes a large vendor file in the webservice package


## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
